### PR TITLE
changing the logic to use drones

### DIFF
--- a/packages/sr2020-model-engine/scripts/qr/drone_library.ts
+++ b/packages/sr2020-model-engine/scripts/qr/drone_library.ts
@@ -353,6 +353,6 @@ export const kAllDrones: Drone[] = [
     abilityIds: ['auto-doc-screen', 'auto-doc-bonus-5'],
   },
 ];
-export const kCommonDroneAbilityIds = ['drone-danger', 'drone-logoff'];
+export const kCommonDroneAbilityIds = ['drone-danger', 'drone-logoff', 'in-drone'];
 
 export const kDroneAbilityIds = new Set(kCommonDroneAbilityIds.concat(...kAllDrones.map((drone) => drone.abilityIds)));

--- a/packages/sr2020-testing/merchandise.spec.ts
+++ b/packages/sr2020-testing/merchandise.spec.ts
@@ -45,7 +45,7 @@ describe('Merchandise', () => {
     expect(droneData.type).toBeDefined();
     expect(droneData.sensor).toBeGreaterThan(0);
     expect(droneData.hitpoints).toBeGreaterThan(0);
-    expect(droneData.passiveAbilities).toHaveLength(1);
+    expect(droneData.passiveAbilities).toHaveLength(2);
     expect(droneData.activeAbilities).toHaveLength(6);
   });
 


### PR DESCRIPTION
Посидели с Гномом и Джином, обсуждая дронов. У нас есть потенциальная проблема, что в дроне/духе/матрице могут гулять бесконечно и мы не можем выбросить их... 
Решили, что можно максимально усложнить жизнь таким персонажам, например отключив им активные абилки дрона и экраны (кроме абилки выхода и повреждения). (api.model.activeAbilities.filter((ability) => kCommonDroneAbilityIds); - я не уверен, что так можно списки фильтровать разве что...
Еще можно долбать их уведомлениями. 

Кроме того сделал срабатывание дополнительного фидбека в зависимости от параметра Боди.

А мы не отфильтровываем пассивные способности в дроне по дрону, потому что, тогда слетят всякие пассивки на основные параметры? По логике Дрон это же Железка, у неё свои параметры, важным может быть разве что интеллект и боди...