### PR TITLE
delete trash abilities

### DIFF
--- a/packages/sr2020-model-engine/scripts/character/active_abilities_library.ts
+++ b/packages/sr2020-model-engine/scripts/character/active_abilities_library.ts
@@ -779,37 +779,6 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
     fadingPrice: 0,
     eventType: investigateScoring.name,
   },
-  // На допросе цель развернуто отвечает на заданный вопрос и теряет одну единицу эссенса (начисляется на Папу Драконов). Абилка-сертификат с кулдауном
-  {
-    id: 'chain-interrogation',
-    humanReadableName: 'Конвейерный допрос',
-    description: 'На допросе цель развернуто отвечает на заданный вопрос и теряет единицу эссенса.',
-    target: 'scan',
-    targetsSignature: kNoTarget,
-    cooldownMinutes: (character) => 60,
-    prerequisites: [],
-    availability: 'master',
-    karmaCost: 0,
-    minimalEssence: 0,
-    fadingPrice: 0,
-    eventType: noItActionAbility.name,
-  },
-  // TODO(https://trello.com/c/XHT0b9Oj/155-реализовать-заклинания-работающие-с-духами)
-  // При использовании абилки Exorcizamus ее коэффициент К=5 (значение может быть изменено для нужд балансировки).
-  {
-    id: 'orthodox-exorcism',
-    humanReadableName: 'Отчитка',
-    description: 'Благословением Божиим ваша способность Exorcizamus срабатывает с кратно увеличенной вероятностью.',
-    target: 'scan',
-    targetsSignature: kNoTarget,
-    cooldownMinutes: (character) => 60,
-    prerequisites: ['arch-mage'],
-    availability: 'master',
-    karmaCost: 0,
-    minimalEssence: 0,
-    fadingPrice: 0,
-    eventType: spiritsRelatedSpell.name,
-  },
   // Время действия 60 минут. Кулдаун 40 минут. Аура цели на это время случайным образом меняется на 20% (и случайный фрагмент, и на случайное значение).
   {
     id: 'silentium-est-aurum',

--- a/packages/sr2020-model-engine/scripts/character/passive_abilities_library.ts
+++ b/packages/sr2020-model-engine/scripts/character/passive_abilities_library.ts
@@ -3331,15 +3331,6 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
     pack: { id: 'gen-meta-digital', level: 1 },
     modifier: [],
   },
-  {
-    id: 'no-enter-gh',
-    humanReadableName: 'Запрет Доступа',
-    description: 'Покажи эту способность персонажу. Он должен немедленно покинуть заведение, сотрудником которого ты являешься',
-    availability: 'open',
-    karmaCost: 0,
-    prerequisites: ['sub-agent', 'arch-digital'],
-    modifier: [],
-  },
   //
   {
     id: 'arch-digital',

--- a/packages/sr2020-model-engine/scripts/character/spells_library.ts
+++ b/packages/sr2020-model-engine/scripts/character/spells_library.ts
@@ -15,7 +15,6 @@ import {
   fireballSpell,
   frogSkinSpell,
   groundHealSpell,
-  increaseResonanceSpell,
   keepYourselfSpell,
   letItGoSpell,
   liveLongAndProsperSpell,
@@ -39,16 +38,6 @@ import { Spell } from '@alice/sr2020-common/models/common_definitions';
 import { setAllSpells } from '@alice/sr2020-model-engine/scripts/character/library_registrator';
 // Not exported by design, use kAllSpells instead.
 const kAllSpellsList: Spell[] = [
-  {
-    id: 'dummy-spell',
-    humanReadableName: 'Заглушка',
-    description: 'Спелл-заглушка.',
-    prerequisites: [],
-    availability: 'master',
-    karmaCost: 0,
-    sphere: 'aura',
-    eventType: increaseResonanceSpell.name,
-  },
   // маг может увеличить себе максимальные и текущие хиты на N на время T. N=Мощь. T=10*Мощь минут. Хиты не могут стать больше шести
   {
     id: 'keep-yourself',


### PR DESCRIPTION
абилки chain-interrogation и orthodox-exorcism завязаны на этики orthodox-miracle-doers и cold-head-and-hot-heart, в игре использоваться не будут, сами этики не выпиливал.
про кулдауны, там Мёрфи чот нахерачил с духами, это оттуда всякий треш прошёл, но он вроде поправил