### PR TITLE
FIX: arch-mage grants magic+2 (instead of +1)

### DIFF
--- a/packages/sr2020-model-engine/scripts/character/active_abilities.ts
+++ b/packages/sr2020-model-engine/scripts/character/active_abilities.ts
@@ -274,7 +274,12 @@ export function changeAuraEffect(api: EffectModelApi<Sr2020Character>, m: Modifi
   const auraChars: string[] = [];
   for (let i = 0; i < mask.length; ++i) {
     if (mask[i] != kUnknowAuraCharacter) {
-      auraChars.push(mask[i]);
+      if(mask[i] != api.model.magicStats.aura[i]) {
+        auraChars.push(mask[i]);
+      } else {
+        const slide = (mask[i] == 'z')?-25:1;
+        auraChars.push(String.fromCharCode(mask[i].charCodeAt(0) + slide));
+      }
     } else {
       auraChars.push(api.model.magicStats.aura[i]);
     }

--- a/packages/sr2020-model-engine/scripts/character/passive_abilities_library.ts
+++ b/packages/sr2020-model-engine/scripts/character/passive_abilities_library.ts
@@ -2005,7 +2005,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
     karmaCost: 100,
     prerequisites: ['!arch-hackerman-technomancer', '!magic-blockade'],
     pack: { id: 'gen-arch-mage', level: 1 },
-    modifier: [modifierFromEffect(increaseMagic, { amount: 1 })],
+    modifier: [modifierFromEffect(increaseMagic, { amount: 2 })],
   },
   // Magic +2
   // body +2

--- a/packages/sr2020-testing/passive_abilities.spec.ts
+++ b/packages/sr2020-testing/passive_abilities.spec.ts
@@ -1,0 +1,21 @@
+import { TestFixture } from './fixture';
+
+describe('Passive abilities', function () {
+  let fixture: TestFixture;
+
+  beforeEach(async () => {
+    fixture = await TestFixture.create();
+  });
+
+  afterEach(async () => {
+    await fixture.destroy();
+  });
+
+  it('Archetype Mage', async () => {
+    await fixture.saveCharacter({ magic: 1 });
+    await fixture.addCharacterFeature('arch-mage');
+    const { workModel } = await fixture.getCharacter();
+    expect(workModel.magic).toBe(3);
+  });
+
+});


### PR DESCRIPTION
Fixed: passive ability 'arch-mage' should grants +2 to Magic attribute instead of +1.

https://trello.com/c/2Ircc8vA/861-%D1%81%D0%B4%D0%B5%D0%BB%D0%B0%D1%82%D1%8C-%D0%B1%D0%BE%D0%BD%D1%83%D1%81-%D0%BE%D1%82-%D0%B0%D1%80%D1%85%D0%B5%D1%82%D0%B8%D0%BF%D0%B0-%D0%BC%D0%B0%D0%B3-2-%D0%BA-%D0%BC%D0%B0%D0%B3%D0%B8%D0%B8