### PR TITLE
REIMPORT: spirit abs separated from the mage ones

### DIFF
--- a/packages/sr2020-model-engine/scripts/character/active_abilities.ts
+++ b/packages/sr2020-model-engine/scripts/character/active_abilities.ts
@@ -154,10 +154,6 @@ export function arrowgant(api: EventModelApi<Sr2020Character>, data: ActiveAbili
   addTemporaryPassiveAbility(api, 'arrowgant-effect', d);
 }
 
-export function arr_ow(api: EventModelApi<Sr2020Character>, data: ActiveAbilityData) {
-  addTemporaryPassiveAbility(api, 'arrowgant-effect', duration(10, 'minutes'));
-}
-
 export function trollton(api: EventModelApi<Sr2020Character>, data: ActiveAbilityData) {
   const manaLevel = data.location.manaLevel;
   const d = duration(5 + 2 * manaLevel, 'minutes');

--- a/packages/sr2020-model-engine/scripts/character/active_abilities_library.ts
+++ b/packages/sr2020-model-engine/scripts/character/active_abilities_library.ts
@@ -2,7 +2,6 @@ import {
   absoluteDeathAbility,
   activateSoft,
   alloHomorusAbility,
-  arr_ow,
   arrowgant,
   astralopithecus,
   avalFest,
@@ -906,11 +905,13 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
     fadingPrice: 0,
     eventType: reviveOnTarget.name,
   },
-  // Активация дает возможность открыть замок (см.правила по взломам в "Прочих моделях"). Кулдаун - 20 минут
+  // Активация дает возможность тихо открыть один замок за 1 минуту - все это время надо держаться рукой за сертификат замка.
+  // Требуемая эссенция: больше 2. Кулдаун 20 минут
   {
     id: 'allo-homorus',
     humanReadableName: 'Allo, homorus! (A)',
-    description: 'Активация дает возможность открыть один замок. Требуемая эссенция: больше 2. Кулдаун 20 минут',
+    description:
+      'Активация дает возможность тихо открыть один замок за 1 минуту - все это время надо держаться рукой за сертификат замка.\nТребуемая эссенция: больше 2. Кулдаун 20 минут',
     target: 'scan',
     targetsSignature: kNoTarget,
     cooldownMinutes: (character) => 20,
@@ -3836,7 +3837,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // Время действия 80 минут. Аура цели на это время случайным образом меняется на 30% (и случайный фрагмент, и на случайное значение).
   {
     id: 'aurma',
-    humanReadableName: 'Aurma',
+    humanReadableName: 'ДУХ: Aurma',
     description: 'На 80 минут частично изменить другому персонажу его ауру. Кулдаун 60 минут',
     target: 'scan',
     targetsSignature: [
@@ -3854,11 +3855,13 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
     fadingPrice: 0,
     eventType: changeAuraSpiritAbility.name,
   },
-  // Активация дает возможность открыть замок (см.правила по взломам в "Прочих моделях"). Кулдаун - 5 минут
+  // Активация дает возможность тихо открыть один замок за 1 минуту - все это время надо держаться рукой за сертификат замка.
+  // Кулдаун 5 минут
   {
     id: 'i-shall-pass',
-    humanReadableName: 'I shall pass',
-    description: 'Активация дает возможность открыть один замок. Кулдаун 5 минут',
+    humanReadableName: 'ДУХ: I shall pass',
+    description:
+      'Активация дает возможность тихо открыть один замок за 1 минуту - все это время надо держаться рукой за сертификат замка.\nКулдаун 5 минут',
     target: 'scan',
     targetsSignature: kNoTarget,
     cooldownMinutes: (character) => 5,
@@ -3869,25 +3872,10 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
     fadingPrice: 0,
     eventType: alloHomorusAbility.name,
   },
-  // - время действия 10 минут, кулдаун 15 минут. Дает абилку arrowgant-effect на это время.
-  {
-    id: 'arr-ow',
-    humanReadableName: 'Arr! Ow...',
-    description: 'Активируемая защита от дистанционного легкого оружия. Время действия 10 минут. Кулдаун 15 минут.',
-    target: 'scan',
-    targetsSignature: kNoTarget,
-    cooldownMinutes: (character) => 15,
-    prerequisites: ['arch-mage'],
-    availability: 'master',
-    karmaCost: 0,
-    minimalEssence: 0,
-    fadingPrice: 0,
-    eventType: arr_ow.name,
-  },
   // у цели сканируется QR, она из тяжрана/КС переходит в состояние "здоров и в максимальных хитах"
   {
     id: 'undiena',
-    humanReadableName: 'Undiena',
+    humanReadableName: 'ДУХ: Undiena',
     description: 'Активируемая возможность поднять одну цель из КС/тяжрана в полные хиты. Время действия: 30 минут',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -3902,7 +3890,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // У духа появляется на 3 минуты пассивная абилка avalanche-able. amount=4. Пояснение как должно работать - сопровождающий мага мастер всем рассказывает, что у них хиты упали. Для подтверждения может показать текст.
   {
     id: 'aval-festival',
-    humanReadableName: 'Aval-festival',
+    humanReadableName: 'ДУХ: Aval-festival',
     description:
       'Снять со всех персонажей в реале в радиусе 5 метров от точки активации хиты в количестве 4. Действует на всех, кроме самого духа и тех, кого он укажет. \nРекомендуется привлекать для подтверждения эффекта представителя МГ.',
     target: 'scan',
@@ -3919,7 +3907,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // Пояснение как должно работать - сопровождающий мага мастер всем рассказывает, что у них хиты падают. Для подтверждения может показать текст.
   {
     id: 'date-of-birds',
-    humanReadableName: 'Date of birds',
+    humanReadableName: 'ДУХ: Date of birds',
     description:
       'В течение 15 минут каждую минуту со всех в реале в радиусе 5 метров от точки активации эффекта снимается по 1 хиту (рекомендуется привлекать для подтверждения эффекта представителя МГ). \nДействует на всех, кроме самого духа и тех, кого он укажет.\nЕсли дух отходит от точки активации больше чем на 2 метра - действие эффекта прекращается.',
     target: 'scan',
@@ -3935,7 +3923,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // После активации эффекта в приложении выводятся текстом данные о заклинаниях, сотворенных в этой локации в последние 15 минут - список (название заклинания,  Мощь, Откат, 40% ауры творца, метарасу творца).
   {
     id: 'trackpointer',
-    humanReadableName: 'Trackpointer',
+    humanReadableName: 'ДУХ: Trackpointer',
     description:
       'Получить данные обо всех заклинаниях, обнаруженных в этой локации за последние 25 минут.  Ауры считываются на 40 процентов',
     target: 'scan',
@@ -3951,7 +3939,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // После активации эффекта в приложении выводятся текстом данные о заклинаниях, сотворенных в этой локации в последние 15 минут - список (название заклинания,  Мощь, DMX Отката, 80% ауры творца, метарасу творца).
   {
     id: 'trackeeteer',
-    humanReadableName: 'Trackeeteer',
+    humanReadableName: 'ДУХ: Trackeeteer',
     description:
       'Получить данные обо всех заклинаниях, обнаруженных в этой локации за последние 15 минут.  Ауры считываются на 80 процентов',
     target: 'scan',
@@ -3967,7 +3955,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // В течение 15 минут каждые 60с будет безусловно вытягиваться 1 уровень плотности маны из случайной соседней локации в текущую (там понизится, тут повысится).
   {
     id: 'get-high',
-    humanReadableName: 'Get high',
+    humanReadableName: 'ДУХ: Get high',
     description: 'В течение 15 минут мана из соседних локаций периодически будет призываться в эту',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -3982,7 +3970,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // В течение 15 минут каждые 60с 1 уровень плотности маны будет безусловно выгоняться в случайную соседнюю локацию (там понизится, тут повысится).
   {
     id: 'get-low',
-    humanReadableName: 'Get low',
+    humanReadableName: 'ДУХ: Get low',
     description: 'В течение 15 минут мана из этой локации будет изгоняться в соседние',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -3997,7 +3985,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // дух узнает часть ауры цели (95% для метачеловека, не сопротивляющегося сканированию своего qr).
   {
     id: 'auriel',
-    humanReadableName: 'Auriel',
+    humanReadableName: 'ДУХ: Auriel',
     description: 'Узнать 95% ауры не сопротивляющегося человека',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -4012,7 +4000,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // дух узнает ауру текущей локации
   {
     id: 'reefwise',
-    humanReadableName: 'Reefwise',
+    humanReadableName: 'ДУХ: Reefwise',
     description: 'Узнать ауру локации',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -4027,7 +4015,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // у цели на 60 минут понижается Резонанс на 3.
   {
     id: 'surge-the-unclean',
-    humanReadableName: 'Surge the unclean',
+    humanReadableName: 'ДУХ: Surge the unclean',
     description: 'На 60 минут понизить на 3 Резонанс цели, указанной добровольно предоставленным qr-кодом.',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -4042,7 +4030,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // у цели на 60 минут понижается Харизма на 2.
   {
     id: 'ugly-is-pechi',
-    humanReadableName: 'Ugly is pechi',
+    humanReadableName: 'ДУХ: Ugly is pechi',
     description: 'На 60 минут понизить на 2 Харизму цели, указанной добровольно предоставленным qr-кодом.',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -4057,7 +4045,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // у цели на 60 минут повышается Харизма на 2 - но не выше 5
   {
     id: 'beautti-frutti',
-    humanReadableName: 'Beautti-frutti',
+    humanReadableName: 'ДУХ: Beautti-frutti',
     description: 'На 60 минут повысить Харизму на 2, но не выше 5, цели, указанной добровольно предоставленным qr-кодом.',
     target: 'scan',
     targetsSignature: kNoTarget,
@@ -4532,7 +4520,7 @@ export const kAllActiveAbilitiesList: ActiveAbility[] = [
   // В нотификации выводится уровень маны в текущей локации
   {
     id: 'i-feel-it-in-the-water',
-    humanReadableName: 'I feel it in the water',
+    humanReadableName: 'ДУХ: I feel it in the water',
     description: 'Увидеть уровень маны в локации',
     target: 'scan',
     targetsSignature: kNoTarget,

--- a/packages/sr2020-model-engine/scripts/character/passive_abilities_library.ts
+++ b/packages/sr2020-model-engine/scripts/character/passive_abilities_library.ts
@@ -177,11 +177,11 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
     pack: { id: 'gen-meta-ork', level: 1 },
     modifier: [modifierFromEffect(increaseMaxMeatHp, { amount: 1 })],
   },
-  // magicStats.spiritResistanceMultiplier *0.8
+  // Увеличивает вероятность поимки духов на 20%
   {
     id: 'spirit-feed',
-    humanReadableName: 'Знакомец духов',
-    description: 'Снижает Сопротивление духов этому магу.',
+    humanReadableName: 'Друг духов',
+    description: 'Тебе заметно легче ловить духов',
     availability: 'master',
     karmaCost: 0,
     prerequisites: [],
@@ -387,12 +387,12 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
     prerequisites: ['media-person'],
     modifier: [],
   },
-  // для проект-менеджера  с 1 слотом
+  //
   // У игрока просто отображается текст пассивной абилки
   {
     id: 'project-manager-1',
     humanReadableName: 'ты - проект-менеджер',
-    description: 'Сертификат проект-менеджера. Ты можешь вести проекты, но необходимо выбрать специализацию (тип проекта). ',
+    description: 'Сертификат проект-менеджера. Ты можешь вести проекты. Для каждого типа проектов необходим соответствующий навык.',
     availability: 'closed',
     karmaCost: 0,
     prerequisites: [],
@@ -2623,7 +2623,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
       'Если тебя связали - ты можешь развязаться в любой момент по своему желанию.  Необходимо громко должны сказать “развязался” и скинуть веревочные петли. ',
     availability: 'open',
     karmaCost: 30,
-    prerequisites: ['binding', 'arch-face'],
+    prerequisites: ['arch-face'],
     modifier: [],
   },
   // текстовая абилка
@@ -3995,7 +3995,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   // модельного эффекта нет
   {
     id: 'mr-cellophane',
-    humanReadableName: 'Mr.Cellophane',
+    humanReadableName: 'ДУХ: Mr.Cellophane',
     description:
       'Ты находишься в астральном плане. Необходимый маркер: красный дождевик.\nТы видишь и слышишь реальный мир, но не можешь воздействовать на него.\nИз реального мира тебя не воспринимают и никак не могут атаковать (если только у них нет абилки, которая явным образом утверждает иное).',
     availability: 'master',
@@ -4006,7 +4006,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   // модельного эффекта нет
   {
     id: 'hammer-time',
-    humanReadableName: 'HammerTime',
+    humanReadableName: 'ДУХ: HammerTime',
     description: 'Можешь взять одноручное холодное оружие до 100см, оно считается тяжёлым.',
     availability: 'master',
     karmaCost: 0,
@@ -4016,7 +4016,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   // модельного эффекта нет
   {
     id: 'adamantaeu',
-    humanReadableName: 'Adamantaeu',
+    humanReadableName: 'ДУХ: Adamantaeu',
     description: 'На тебя действует эффект тяжёлой брони.',
     availability: 'master',
     karmaCost: 0,
@@ -4026,7 +4026,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   //
   {
     id: 'fireball-back',
-    humanReadableName: 'Fireball - back',
+    humanReadableName: 'ДУХ: Fireball - back',
     description: 'Можешь кинуть 3 огненных шара. Затем эффект исчерпан до выхода из духа',
     availability: 'master',
     karmaCost: 0,
@@ -4036,7 +4036,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   //
   {
     id: 'fireball-halfback',
-    humanReadableName: 'Fireball - halfback',
+    humanReadableName: 'ДУХ: Fireball - halfback',
     description: 'Можешь кинуть 5 огненных шаров. Затем эффект исчерпан до выхода из духа',
     availability: 'master',
     karmaCost: 0,
@@ -4046,7 +4046,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   //
   {
     id: 'fireball-forward',
-    humanReadableName: 'Fireball - forward',
+    humanReadableName: 'ДУХ: Fireball - forward',
     description: 'Можешь кинуть 9 огненных шаров. Затем эффект исчерпан до выхода из духа',
     availability: 'master',
     karmaCost: 0,
@@ -4056,7 +4056,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   // Все мясные/экто тела, касающиеся этого духа на протяжении 1 минуты, в конце этого интервала восстанавливают текущие хиты до максимума
   {
     id: 'over-the-pills',
-    humanReadableName: 'Over the pills',
+    humanReadableName: 'ДУХ: Over the pills',
     description:
       'Все мясные/экто тела, касающиеся этого духа на протяжении 1 минуты, в конце этого интервала восстанавливают текущие хиты до максимума',
     availability: 'master',
@@ -4067,7 +4067,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   //
   {
     id: 'fireball-keeper',
-    humanReadableName: 'Fireball - keeper',
+    humanReadableName: 'ДУХ: Fireball - keeper',
     description: 'Можешь кинуть 2 огненных шара. Затем эффект исчерпан до выхода из духа',
     availability: 'master',
     karmaCost: 0,
@@ -4077,7 +4077,7 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
   // Все мясные/экто тела, щекочущие владельца абилки на протяжении 2 минут, в конце этой минуты восстанавливают текущие хиты до максимума
   {
     id: 'tick-a-lick-a-boo',
-    humanReadableName: 'Tick-a-lick-a-boo',
+    humanReadableName: 'ДУХ: Tick-a-lick-a-boo',
     description:
       'Все мясные/экто тела, щекочущие этого духа на протяжении 2 минут, в конце этого интервала восстанавливают текущие хиты до максимума',
     availability: 'master',
@@ -4316,6 +4316,26 @@ const kAllPassiveAbilitiesList: PassiveAbility[] = [
     availability: 'open',
     karmaCost: 50,
     prerequisites: ['arch-mage', 'spirit-master-2'],
+    modifier: [],
+  },
+  // Вероятность поимки духов увеличивается на 10%
+  {
+    id: 'spirit-known',
+    humanReadableName: 'Знакомый духов (P)',
+    description: 'Тебе легче ловить духов',
+    availability: 'open',
+    karmaCost: 20,
+    prerequisites: ['arch-mage'],
+    modifier: [],
+  },
+  // модельного эффекта нет
+  {
+    id: 'arr-ow',
+    humanReadableName: 'ДУХ: Arr! Ow...',
+    description: 'Защита от дистанционного легкого оружия.',
+    availability: 'master',
+    karmaCost: 0,
+    prerequisites: ['arch-mage'],
     modifier: [],
   },
 ];

--- a/packages/sr2020-testing/active_abilities.spec.ts
+++ b/packages/sr2020-testing/active_abilities.spec.ts
@@ -121,21 +121,6 @@ describe('Active abilities', function () {
     }
   });
 
-  it('Arr-ow', async () => {
-    await fixture.saveCharacter();
-    await fixture.addCharacterFeature('arr-ow');
-
-    {
-      const { workModel } = await fixture.useAbility({ id: 'arr-ow' });
-      expect(workModel.passiveAbilities).toContainEqual(
-        expect.objectContaining({
-          id: 'arrowgant-effect',
-          validUntil: 10 * 60 * 1000,
-        }),
-      );
-    }
-  });
-
   it('Undiena', async () => {
     await fixture.saveCharacter();
     await fixture.addCharacterFeature('undiena');


### PR DESCRIPTION
К имени всех абилок, выдаваемым духам, добавлен префикс "ДУХ: " - чтобы в Еве можно было отличать пассивные абилки мага (не действующие на духа) и пассивные абилки духа.