### PR TITLE
FIX: adding various messages to user about danger of the clinicalDeat…

### DIFF
--- a/packages/sr2020-model-engine/scripts/character/spirits.ts
+++ b/packages/sr2020-model-engine/scripts/character/spirits.ts
@@ -95,6 +95,12 @@ export function zeroSpiritAbilities(api: EventModelApi<Sr2020Character>, data: n
     }
   }
   m.abilityIds = kCommonSpiritAbilityIds;
+  sendNotificationAndHistoryRecord(
+    api,
+    'Эктоплазма разрушается',
+    'Вам нужно срочно вернуться в мясное тело, иначе через 10 минут наступит клиническая смерть',
+  );
+  api.setTimer('zeroSpiritTimeToDie', 'Клиническая смерть, если не успеете вернуться в мясное тело', duration(10, 'minutes'), '_', {});
 }
 
 export function emergencySpiritExit(api: EventModelApi<Sr2020Character>, data: unknown) {


### PR DESCRIPTION
…h at zeroSpiritAbilities event

Полезной работы тут нет, только максимальное информирование пользователя о том, что через 10 минут он упадёт в КС, если не выйдет из духа

@aeremin Я пытался написать тест, не осилил подготовку контекста перед вызовом ивента. Если подскажешь, как правильно его вызвать, то я добавлю проверки нотификации/истории/таймера + исчезновение таймера через 10 минут.